### PR TITLE
Fixes error main_factor is of length zero in R4

### DIFF
--- a/TEdiff.R
+++ b/TEdiff.R
@@ -153,7 +153,7 @@ output_figures_fit = c(paste0(outdir, "/DispEsts"),
                           paste0(outdir, "/MA"))
 
 # differential analysis between every pair of variable 1
-main_factor = levels(variables[,1])
+main_factor = levels(as.factor(variables[,1]))
 i = 1
 j = 1
 n = length(main_factor)


### PR DESCRIPTION
This PR adresses issue #10.
Using R v4, TEdif.R returned an error at line 156 because `variables[,1]` is not a factor. So I replaced `levels(variables[,1])` with `levels(as.factor(variables[,1]))`.